### PR TITLE
Support manual planning turned on in PT project settings

### DIFF
--- a/app/public/js/tt.init.js
+++ b/app/public/js/tt.init.js
@@ -48,7 +48,7 @@ TT.Init = (function () {
       name: 'Unstarted',
       active: true,
       filter: function (story) {
-        return story.current_state === 'unstarted';
+        return story.current_state === 'unstarted' || story.current_state === 'planned';
       },
       onDragIn: function (story) {
         return { current_state: 'unstarted' };


### PR DESCRIPTION
The current build does not work when you have Manual Planning turned on in the Pivotal Tracker settings when you look for unstarted stories in the current iteration. This is because PT uses a new story status of 'unplanned'; this pull request adds that status to the filter for the Unstarted column.